### PR TITLE
Handle cases where signals are missed.

### DIFF
--- a/kapture/__main__.py
+++ b/kapture/__main__.py
@@ -24,7 +24,7 @@ def main(command_args):
             process.send_signal(signal.SIGINT)
             # Uniformly jitter the samples
             time.sleep(PERIOD - interval)
-            interval = random.uniform(0, PERIOD)
+            interval = random.uniform(0.5*PERIOD, PERIOD)
             time.sleep(interval)
             i += 1
     finally:


### PR DESCRIPTION
As described here: https://docs.python.org/3/library/signal.html
> A long-running calculation implemented purely in C (such as regular expression matching on a large body of text) may run uninterrupted for an arbitrary amount of time, regardless of any signals received. The Python signal handlers will be called when the calculation finishes.

Because of this, it is possible that many signals will be recieved but a log will be written only once. This pull attempts to fix this by estimating how many signals should have been recieved since the last one was handled. In order to get a more accurate calculation, the way signals are jittered has also been changed.