### PR TITLE
Remove PyPI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Kapture currently needs to run inside the installation of Python you wish to pro
 It is written in pure python and depends only on the standard library (mostly pdb).
 The visualisation component of kapture depends on matplotlib and numpy.
 
-Kapture can be pip installed with:
-
-    pip install kapture
-
 Kapture can be installed from the source directory with:
 
     pip install .


### PR DESCRIPTION
The "kapture" project on PyPI doesn't relate to this code (see #5), so these instructions need to be removed otherwise people (e.g. me) might accidentally install completely the wrong project. 🙄 